### PR TITLE
Fix only refresh the actual root node, if it's enabled

### DIFF
--- a/Runtime/FlexLayout.cs
+++ b/Runtime/FlexLayout.cs
@@ -483,7 +483,7 @@ namespace Gilzoide.FlexUi
             try
             {
                 await Task.Yield();
-                if (root)
+                if (root && root.IsActive() && root.IsRootLayoutNode)
                 {
                     root.RefreshLayout();
                 }


### PR DESCRIPTION
This fixes NaN positions set in children that don't even have FlexLayouts.