### PR TITLE
Fix crash under IL2CPP resulting indirectly from incorrect boolean marshalling

### DIFF
--- a/Runtime/Yoga/Yoga.cs
+++ b/Runtime/Yoga/Yoga.cs
@@ -20,7 +20,7 @@ namespace Gilzoide.FlexUi.Yoga
 
         [DllImport(YogaDll, EntryPoint = "FlexUi_ConfigSetPointScaleFactor")] public static extern void YGConfigSetPointScaleFactor(IntPtr config, float enabled);
         [DllImport(YogaDll, EntryPoint = "FlexUi_ConfigSetErrata")] public static extern void YGConfigSetErrata(IntPtr config, Errata errata);
-        [DllImport(YogaDll, EntryPoint = "FlexUi_ConfigSetExperimentalFeatureEnabled")] public static extern void YGConfigSetExperimentalFeatureEnabled(IntPtr config, ExperimentalFeature feature, bool enabled);
+        [DllImport(YogaDll, EntryPoint = "FlexUi_ConfigSetExperimentalFeatureEnabled")] public static extern void YGConfigSetExperimentalFeatureEnabled(IntPtr config, ExperimentalFeature feature, [MarshalAs(UnmanagedType.U1)] bool enabled);
 
         #endregion
 
@@ -41,7 +41,7 @@ namespace Gilzoide.FlexUi.Yoga
         [DllImport(YogaDll, EntryPoint = "FlexUi_NodeSetContext")] public static extern void YGNodeSetContext(IntPtr node, IntPtr context);
         [DllImport(YogaDll, EntryPoint = "FlexUi_NodeGetContext")] public static extern IntPtr YGNodeGetContext(IntPtr node);
         [DllImport(YogaDll, EntryPoint = "FlexUi_NodeSetMeasureFunc")] public static extern void YGNodeSetMeasureFunc(IntPtr node, IntPtr measureFunc);
-        [DllImport(YogaDll, EntryPoint = "FlexUi_NodeHasMeasureFunc")] public static extern bool YGNodeHasMeasureFunc(IntPtr node);
+        [DllImport(YogaDll, EntryPoint = "FlexUi_NodeHasMeasureFunc")] [return: MarshalAs(UnmanagedType.U1)] public static extern bool YGNodeHasMeasureFunc(IntPtr node);
         [DllImport(YogaDll, EntryPoint = "FlexUi_NodeSetDirty")] public static extern void YGNodeSetDirty(IntPtr node);
 
         public delegate Vector2 YGMeasureFunc(IntPtr nodePtr, float width, MeasureMode widthMode, float height, MeasureMode heightMode);


### PR DESCRIPTION
This applies the `[MarshalAs(UnmanagedType.U1)]` attribute to `YGConfigSetExperimentalFeatureEnabled` and `YGNodeHasMeasureFunc` to ensure `bool` gets marshalled as a 1-byte value instead of the default 4 bytes (i.e. the Windows `BOOL` type).

This issue resulted in the return value of `YGNodeHasMeasureFunc` not working correctly under IL2CPP, which later caused `YGNodeSetDirty` to get incorrectly called when a measure function was set, causing an assertion to fail.